### PR TITLE
pull_request_template: Create starter PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,10 @@
 ## Changes
 
-Type of change: [attack/defense/evaluation/infra/misc]
+Summarize the changes in this PR and describe the context or motivation for
+them.
 
-Summarize the changes in this PR and describe context or motivation for them.
+Add a title, prepending the tag [attack], [defense], [evaluation], or [infra] if
+appropriate.
 
 ## Testing
 


### PR DESCRIPTION
## Changes

Adds simple PR template, which should automatically get picked up by GitHub based on [GH docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository#adding-a-pull-request-template).

I'm keeping it very simple here while the benchmark is under internal development. If the PR template is long then people will just start ignoring parts of it. However if we open up the benchmark to public contribution then we should make the PR template more thorough to convey expectations to public contributors.

Additional suggestions from Saad in [onboarding doc draft](https://docs.google.com/document/d/1e2ptPrFAgUWFImuE_LUMha9GRV3yYs_HImgEEU2xsgc/edit?tab=t.0#heading=h.ccygfp37wwse), + my own remarks for why I haven't added them to template:
- Reference the ticket or discussion in the PR description
  - Agreed if we start using Linear, but not clear yet we'll use it
- Clearly explain what the PR contains and what area it affects (attack/defense/eval/infra)
  - Re which area it affects — seems reasonable, I'm not sure whether we want to put it in PR template vs. in PR title vs. use GitHub tags
- Cite relevant papers or materials (preferably with link + bibtex) if adding or porting implementation of method
  - Agreed but I think this should go in the file or class header inside the codebase


## Testing

None, but does not affect main code. TODO once merged: Check PR template is applied in a new PR.