### PR TITLE
scripts: Add LLM-as-a-judge re-evaluation of MMLU-Pro results

### DIFF
--- a/scripts/user/tomtseng/mmlu_pro_llm_judge/README.md
+++ b/scripts/user/tomtseng/mmlu_pro_llm_judge/README.md
@@ -1,0 +1,100 @@
+Note: The contents of this directory used a lot of LLM assistance and the code has not
+been reviewed carefully.
+
+# MMLU-Pro LLM-as-a-judge evaluation
+
+Checks the MMLU-Pro responses from Oct 29 2025 runs (runs for our first arXiv
+release): do the extracted regex results match up with LLM-as-a-judge results?
+
+If there is a large mismatch, that could indicate that the regex results fail to
+capture some knowledge capabilities, and are instead partially measuring gap
+that comes from reduced ability to carefully instruction-follow and answer the
+question in the expected format.
+
+Files:
+- `extract_sample_output.py` samples a bunch of MMLU-Pro responses and the
+  regex-parsed single-letter answers from the responses
+- `judge.py`: LLM judge for extracting MMLU-Pro single-letter answers from
+  responses
+- `run_judge.py`: Runs judge on each sampled response and checks that the LLM
+  judge answers match the regex-parsed answers, printing mismatches to
+  /tmp/judge_mismatches.txt.
+
+## Results Analysis
+
+Ran the LLM judge (GPT-4) on 6,468 MMLU-Pro responses and compared with regex-based answer extraction. Overall agreement: **97.8%** (144 mismatches).
+
+Overall there is good agreement between the regex extraction and the
+LLM-as-a-judge.
+
+### LLM judge found no answer, regex did (98 cases, 68% of mismatches)
+
+The most common type of mismatch. Usually here the regex is wrong: the regex fallback pattern looks for the last standalone capital letter (`\b[A-J]\b`), which often is not an actual attempt at answering the question.
+
+**Common subcategories:**
+
+a) **Pathological repetitive text**
+   - Same sentence repeated 50-200+ times (Rows 14, 40, 56, 84, 120, 156, 182, 238, 420, 732), no answer given
+
+b) **Truncated/incomplete responses** (Rows 42, 326):
+   - Response cuts off mid-sentence: `A subset H of a group (G,*) is a group if`
+   - No actual answer in text, but regex finds letter
+
+c) **Complex formatted text** (Rows 438, 483, 663):
+   - Truth tables with many rows of symbolic logic
+   - Regex picks up a capital letter "F" from table structure
+
+### LLM judge is wrong
+
+The judge can get confused:
+- Judge returns an answer that is not in the response (e.g., rows 219, 369, 719)
+- Response contains multiple answers, it's ambiguous what answer the judge
+  should pick (e.g., rows 102, 434)
+
+### Regex misses legitimate answers
+
+Non-standard but clear phrasings the regex doesn't catch:
+- Row 2168: "Le choix correct est le b."
+- Row 270: "The purchase of a new car by a car rental company would be classified under C."
+- Row 419: "we can conclude that (H) is the correct answer"
+- Row 748: "The answer 'Tdc' appears in (E)" → Regex: C, Judge: E ✓
+- Row 912: "therefore, (E) must be the correct answer"
+- Row 3599: "answer (D)"
+ - Note that regex parsing for `(<answer>)` may also give false results in
+   the opposite direction. Row 102: "The answer (B) is not correct."
+
+### Recommendations for Future Work
+
+1. Try ablating the final fallback regex:
+```python
+def extract_final(text):
+    pattern = r"\b[A-J]\b(?!.*\b[A-J]\b)"
+    match = re.search(pattern, text, re.DOTALL)
+```
+This is the regex responsible for most of the cases where the regex incorrectly
+finds an answer when the LLM judge does not. What happens if we remove this
+regex? It'll remove a lot of those wrong cases---but conversely our analysis
+here does not consider that it may also remove correct cases where this final
+fallback regex catches the correct answer.
+
+2. There are a lot of responses where the response continues by generating new
+   questions and answering them. This can be confusing to parse (both from a
+   regex and an LLM-as-a-judge standpoint). This is probably a result of the
+   few-shot format, unclear MMLU-Pro instructions (which is the fault of the
+   MMLU-Pro authors, not us), and of models being incapable.
+
+   Consider stripping anything after "\nQuestion:" from the responses to cut
+   most cases of these confabulated questions. (Hopefully there are very few
+   cases where models actually legitimately output "\nQuestion:" as a rhetorical
+   device in their CoT reasoning.)
+
+3. If re-running this LLM-as-a-judge, modify the system prompt to make the judge
+   respond "n/a" if the response spams a bunch of inconsistent answers.
+
+### Limitations
+
+A reasonable conclusion is that since only 2% of answers were mismatched, the
+regex evaluation is good enough. However it's possible that mismatched answers
+were concentrated in some models/attacks. As an extreme case, imagine that all
+the mismatched answers came from a single attacked model. In that case we cannot
+trust the MMLU-Pro regex scores for that model.

--- a/scripts/user/tomtseng/mmlu_pro_llm_judge/extract_sample_output.py
+++ b/scripts/user/tomtseng/mmlu_pro_llm_judge/extract_sample_output.py
@@ -1,0 +1,103 @@
+"""Samples one random row from each mmlu_pro_val/inferences.parquet file.
+
+This is meant to be run on the CAIS cluster.
+
+Fetches a sample (one row from each Optuna trial from each attacked model) of
+MMLU-Pro responses from /data/saad_hossain/SafeTuneBed/results/oct29_trial (runs
+for our first arXiv release) and outputs them into /tmp/out.parquet, with
+columns:
+- file: Full path to the parquet file
+- row_index: The randomly sampled row index (0-indexed) from the file
+- response: The response text with "PRED: <letter>" removed
+- prediction: The extracted letter (A-J) from "PRED: <letter>", or "n/a" if no prediction was found
+
+This is for getting a sampling of what MMLU-Pro outputs look like among all of our models and attacks.
+"""
+
+import random
+import re
+from pathlib import Path
+
+import pandas as pd
+
+# Set seed for reproducibility (optional - remove if you want different results each time)
+random.seed(42)
+
+# Find all matching files
+parquet_files = list(
+    Path("/data/saad_hossain/SafeTuneBed/results/oct29_trial").rglob(
+        "mmlu_pro_val/inferences.parquet"
+    )
+)
+
+data = []
+
+for file_path in sorted(parquet_files):
+    try:
+        # Read the parquet file
+        df = pd.read_parquet(file_path)
+
+        # Get a random row from the response column
+        if "response" in df.columns and len(df) > 0:
+            # Sample a random index
+            random_idx = random.randint(0, len(df) - 1)
+            sampled_response = df["response"].iloc[random_idx]
+
+            # Extract prediction from "PRED: <letter>" at the end
+            # Look for "PRED:" followed by optional whitespace and optional letter
+            pred_pattern = r"PRED:\s*([A-Z])?"
+            match = re.search(pred_pattern, sampled_response)
+
+            if match:
+                prediction = match.group(1) if match.group(1) else "n/a"
+                # Remove the "PRED: <answer>" part from response
+                response_cleaned = re.sub(
+                    pred_pattern + r".*$", "", sampled_response
+                ).strip()
+            else:
+                prediction = "n/a"
+                response_cleaned = sampled_response
+
+            data.append(
+                {
+                    "file": str(file_path),
+                    "row_index": random_idx,
+                    "response": response_cleaned,
+                    "prediction": prediction,
+                }
+            )
+        else:
+            data.append(
+                {
+                    "file": str(file_path),
+                    "row_index": -1,
+                    "response": "[No response column or empty file]",
+                    "prediction": "n/a",
+                }
+            )
+    except Exception as e:
+        data.append(
+            {
+                "file": str(file_path),
+                "row_index": -1,
+                "response": f"[Error reading file: {e}]",
+                "prediction": "n/a",
+            }
+        )
+
+# Create DataFrame
+result_df = pd.DataFrame(data)
+
+# Save as parquet (efficient and preserves types)
+output_path = Path("/tmp/out.parquet")
+result_df.to_parquet(output_path, index=False)
+
+print(f"Extracted {len(result_df)} entries and saved to /tmp/out.parquet")
+print(f"\nDataFrame shape: {result_df.shape}")
+print(f"\nColumn names: {list(result_df.columns)}")
+print("\nFirst few rows:")
+print(result_df.head())
+print("\nRow index statistics:")
+print(result_df["row_index"].describe())
+print("\nPrediction value counts:")
+print(result_df["prediction"].value_counts())

--- a/scripts/user/tomtseng/mmlu_pro_llm_judge/judge.py
+++ b/scripts/user/tomtseng/mmlu_pro_llm_judge/judge.py
@@ -1,0 +1,113 @@
+"""LLM judge for extract answers to MMLU-Pro.
+
+Copied from
+https://github.com/AlignmentResearch/scaling-poisoning-internal/pull/101/files
+but with a modified system prompt.
+"""
+
+import asyncio
+import random
+
+import httpx
+from dotenv import load_dotenv
+from openai import APIStatusError, APITimeoutError, AsyncOpenAI, RateLimitError
+
+# Load environment variables from .env file
+load_dotenv()
+
+# ------------ config ------------
+MODEL = "gpt-4.1"
+HTTP_CONNECT_TIMEOUT = 5.0  # DNS/TCP connect
+HTTP_READ_TIMEOUT = 12.0  # server response body
+HTTP_WRITE_TIMEOUT = 12.0
+HTTP_POOL_TIMEOUT = 10.0  # waiting for a free connection from pool
+MAX_RETRIES = 5
+RETRY_DELAY_SECS = 1
+MAX_CONCURRENCY = 600
+# --------------------------------
+
+# Build an explicit httpx client with clear limits/timeouts.
+limits = httpx.Limits(
+    max_connections=128,  # total open sockets
+    max_keepalive_connections=64,  # pooled keepalive sockets
+)
+timeouts = httpx.Timeout(
+    connect=HTTP_CONNECT_TIMEOUT,
+    read=HTTP_READ_TIMEOUT,
+    write=HTTP_WRITE_TIMEOUT,
+    pool=HTTP_POOL_TIMEOUT,
+)
+http_client = httpx.AsyncClient(limits=limits, timeout=timeouts)
+
+client = AsyncOpenAI(
+    http_client=http_client,
+    max_retries=0,  # disable SDK internal retries; we control retries
+)
+
+SYSTEM_PROMPT = """You will be given an answer to a multiple-choice question.
+The response should clearly contain a single-letter response. Return ONLY the letter (A, B, C, D, E, F, G, H, I, J) of the answer.
+
+Look for patterns like "The answer is (X)" where X is a letter. Extract only the letter from the first such occurrence.
+
+Return only the single capital letter with no explanation, no punctuation, no formatting.
+If the response doesn't contain a single-letter answer, response with "n/a" instead.
+
+If the response continues to generate additional multiple-choice questions and answers after the first answer, ignore those subsequent questions and answers, and extract ONLY the letter from the FIRST answer.""".strip()
+
+sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+
+async def _one_call(answer: str) -> str:
+    async with sem:
+        # IMPORTANT: do NOT pass `timeout=` here. Use the httpx client timeout instead.
+        resp = await client.chat.completions.create(
+            model=MODEL,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": answer},
+            ],
+            max_tokens=5,
+            temperature=0,
+        )
+    return resp.choices[0].message.content.strip()
+
+
+async def extract_with_retries(answer: str) -> str:
+    """Extract single-letter answer from MMLU-Pro response.
+
+    Returns "n/a" if no answer was found.
+    """
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            # Let the HTTP client enforce the timeout; avoid double timeouts.
+            return await _one_call(answer)
+
+        except (APITimeoutError, asyncio.TimeoutError) as e:
+            # network/SDK timeout
+            if attempt >= MAX_RETRIES:
+                raise Exception(
+                    f"Max retries ({MAX_RETRIES}) exceeded due to timeout"
+                ) from e
+            await asyncio.sleep(RETRY_DELAY_SECS + random.uniform(0, 0.5))
+
+        except RateLimitError as e:
+            if attempt >= MAX_RETRIES:
+                raise Exception(
+                    f"Max retries ({MAX_RETRIES}) exceeded due to rate limiting"
+                ) from e
+            await asyncio.sleep(RETRY_DELAY_SECS + random.uniform(0.5, 1.5))
+
+        except APIStatusError as e:
+            # Retry 5xx; bail on other 4xx
+            if 500 <= e.status_code < 600 and attempt < MAX_RETRIES:
+                await asyncio.sleep(RETRY_DELAY_SECS + random.uniform(0, 0.5))
+            else:
+                raise Exception(
+                    f"API error (status {e.status_code}) after {attempt} attempts"
+                ) from e
+
+        except Exception as e:
+            # Re-raise unexpected exceptions
+            raise Exception(f"Unexpected error after {attempt} attempts: {e!r}") from e

--- a/scripts/user/tomtseng/mmlu_pro_llm_judge/run_judge.py
+++ b/scripts/user/tomtseng/mmlu_pro_llm_judge/run_judge.py
@@ -1,0 +1,231 @@
+r"""Run LLM judge on MMLU-Pro responses and compare with regex predictions.
+
+This script processes responses from MMLU-Pro evaluations and uses an LLM judge
+(GPT-4) to extract the answer letter from each response. It then compares the
+LLM judge's extraction with the regex-based parsing to validate accuracy.
+
+Features:
+- Automatic checkpointing: Saves progress every 100 completions to allow resume
+- Resume capability: Automatically loads previous results and processes only remaining rows
+- Batched async processing: Processes 500 requests at a time (if we spam too
+  many requests at once then the script will hang)
+- Response preprocessing: Strips confabulated questions after the first answer
+
+Usage:
+    # Process all rows with default checkpoint location
+    uv run python run_judge.py
+
+    # Process only first N rows
+    uv run python run_judge.py --num-rows 100
+
+    # Use custom checkpoint location
+    uv run python run_judge.py --checkpoint /path/to/checkpoint.parquet
+
+    # Resume after interruption (just re-run the same command)
+    uv run python run_judge.py
+
+Important Notes:
+    The script strips everything after "\nQuestion:" from responses before judging
+    to remove confabulated follow-up questions that can confuse the judge. This
+    may affect models that genuinely use "Question:" as a rhetorical device in
+    their chain-of-thought reasoning (hopefully rare).
+"""
+
+import argparse
+import asyncio
+from pathlib import Path
+
+import pandas as pd
+from judge import extract_with_retries
+from tqdm.asyncio import tqdm
+
+CHECKPOINT_INTERVAL = 100  # Save checkpoint every N completions
+BATCH_SIZE = 500  # Process this many async requests at a time
+
+
+def preprocess_response(response: str) -> str:
+    r"""Strip confabulated questions from response.
+
+    Models often generate additional questions after the first answer.
+    We strip everything after "\nQuestion:" to avoid confusing the judge.
+    """
+    question_marker = "\nQuestion:"
+    if question_marker in response:
+        return response[: response.index(question_marker)]
+    return response
+
+
+async def judge_single_response(
+    idx: int, response: str, results: dict, checkpoint_path: Path, completed_count: list
+):
+    """Judge a single response and store result."""
+    try:
+        # Preprocess to remove confabulated questions
+        cleaned_response = preprocess_response(response)
+        result = await extract_with_retries(cleaned_response)
+        results[idx] = result
+
+        # Increment completed count and checkpoint if needed
+        completed_count[0] += 1
+        if completed_count[0] % CHECKPOINT_INTERVAL == 0:
+            await save_checkpoint(checkpoint_path, results)
+
+        return result
+    except Exception as e:
+        print(f"\nError processing row {idx}: {e}")
+        raise
+
+
+async def save_checkpoint(checkpoint_path: Path, results: dict):
+    """Save current results to checkpoint file."""
+    # Convert to dataframe and save
+    checkpoint_df = pd.DataFrame(
+        [{"idx": idx, "judge_prediction": pred} for idx, pred in results.items()]
+    )
+    checkpoint_df.to_parquet(checkpoint_path, index=False)
+    print(f"\nCheckpoint saved: {len(results)} results")
+
+
+async def judge_all_responses(df: pd.DataFrame, checkpoint_path: Path) -> pd.DataFrame:
+    """Run LLM judge on all responses and add results to dataframe."""
+    # Load existing checkpoint if it exists
+    results = {}
+    if checkpoint_path.exists():
+        print(f"Loading checkpoint from {checkpoint_path}...")
+        checkpoint_df = pd.read_parquet(checkpoint_path)
+        results = dict(
+            zip(checkpoint_df["idx"], checkpoint_df["judge_prediction"], strict=False)
+        )
+        print(f"Loaded {len(results)} previous results")
+
+    # Identify which rows still need processing
+    remaining_indices = [i for i in df.index if i not in results]
+    print(
+        f"Processing {len(remaining_indices)} responses (already completed: {len(results)})..."
+    )
+
+    if len(remaining_indices) == 0:
+        print("All responses already processed!")
+        df["judge_prediction"] = df.index.map(results)
+        return df
+
+    # Process in batches to avoid overwhelming the system
+    completed_count = [0]
+    try:
+        for batch_start in range(0, len(remaining_indices), BATCH_SIZE):
+            batch_end = min(batch_start + BATCH_SIZE, len(remaining_indices))
+            batch_indices = remaining_indices[batch_start:batch_end]
+
+            print(
+                f"\nProcessing batch {batch_start // BATCH_SIZE + 1} "
+                f"(rows {batch_start + 1}-{batch_end} of {len(remaining_indices)})..."
+            )
+
+            # Create tasks for this batch
+            tasks = [
+                judge_single_response(
+                    idx,
+                    df.loc[idx, "response"],
+                    results,
+                    checkpoint_path,
+                    completed_count,
+                )
+                for idx in batch_indices
+            ]
+
+            # Run this batch with progress bar
+            await tqdm.gather(*tasks, desc=f"Batch {batch_start // BATCH_SIZE + 1}")
+
+    finally:
+        # Save checkpoint on exit (normal or exception)
+        await save_checkpoint(checkpoint_path, results)
+
+    # Add results to dataframe
+    df["judge_prediction"] = df.index.map(results)
+
+    return df
+
+
+def analyze_results(df: pd.DataFrame):
+    """Compare judge predictions with regex predictions and print statistics."""
+    # Compare predictions (case-insensitive)
+    df["match"] = df["prediction"].str.upper() == df["judge_prediction"].str.upper()
+
+    total = len(df)
+    matches = df["match"].sum()
+    mismatches = total - matches
+    accuracy = matches / total * 100 if total > 0 else 0
+
+    print(f"\n{'=' * 80}")
+    print("RESULTS")
+    print(f"{'=' * 80}")
+    print(f"Total responses: {total}")
+    print(f"Matches: {matches} ({accuracy:.2f}%)")
+    print(f"Mismatches: {mismatches} ({(100 - accuracy):.2f}%)")
+
+    # Save all mismatches to file
+    if mismatches > 0:
+        mismatched_df = df[~df["match"]]
+
+        # Write all mismatches to file
+        mismatch_file = "/tmp/judge_mismatches.txt"
+        with open(mismatch_file, "w") as f:
+            f.write(f"ALL MISMATCHES ({mismatches} total)\n")
+            f.write("=" * 80 + "\n\n")
+
+            for idx, row in mismatched_df.iterrows():
+                f.write(f"\nRow {idx}:\n")
+                f.write(f"  File: {row['file']}\n")
+                f.write(f"  Row index in file: {row['row_index']}\n")
+                f.write(f"  Regex prediction: {row['prediction']}\n")
+                f.write(f"  Judge prediction: {row['judge_prediction']}\n")
+                f.write(f"  Response: {row['response']}\n")
+                f.write("\n" + "-" * 80 + "\n")
+
+        print(f"\nAll mismatches saved to: {mismatch_file}")
+
+    return df
+
+
+async def main():
+    """Entrypoint."""
+    parser = argparse.ArgumentParser(description="Run LLM judge on MMLU-Pro responses")
+    parser.add_argument(
+        "--num-rows",
+        type=int,
+        default=None,
+        help="Number of rows to process (default: all rows)",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default="/tmp/judge_checkpoint.parquet",
+        help="Path to checkpoint file (default: /tmp/judge_checkpoint.parquet)",
+    )
+    args = parser.parse_args()
+
+    # Load data
+    print("Loading data from /tmp/out.parquet...")
+    df = pd.read_parquet("/tmp/out.parquet")
+
+    # Limit to first N rows if specified
+    if args.num_rows is not None:
+        print(f"Limiting to first {args.num_rows} rows...")
+        df = df.head(args.num_rows)
+
+    # Run judge with checkpointing
+    checkpoint_path = Path(args.checkpoint)
+    df = await judge_all_responses(df, checkpoint_path)
+
+    # Analyze results
+    df = analyze_results(df)
+
+    # Save results
+    output_path = "/tmp/out_with_judge.parquet"
+    df.to_parquet(output_path)
+    print(f"\nResults saved to {output_path}")
+    print(f"Checkpoint file: {checkpoint_path} (can be deleted if no longer needed)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Changes

I would not review the code carefully, as it was largely LLM-assisted and I didn't bother trying to make it clean since right now it's a one-off script. I'd mainly read the README.md instead.

However I could imagine this being refactored and turned into something more general — it's quite possible that there are a lot of evals where we could want to double-check with an LLM-as-a-judge whether regex parsing is working well enough.

### Context

When running MMLU evals for the jailbreak-tuning paper we found that jailbreak-tuning could mess with the response format, and using an LLM-as-a-judge gave somewhat better results than using an extensive regex (and writing our own evaluation code gave way more sane results than naively throwing models into `lm-eval` since jailbreak-tuning does require some specific setup and response decoding). I think this was especially problematic for mismatched-generalization (translation languages, caesar shifting) but not so much for competing objectives, but I don't clearly remember.

So we're concerned here about whether we'll see the same gap in TamperBench MMLU-Pro evals. If LLM-as-a-judge does give similar results to regex then we can feel confident just relying on regex

### Implementation

- Sample one MMLU-Pro answer from each optuna trial from each attacked model
- Query GPT-4.1 to extract the single-letter answer from each full answer
- Print out all mismatches between what GPT-4.1 thinks the answer is vs. regex

### Results

Overall agreement: 97.8% (144/6,468 mismatches).

See the `README.md` in this PR for slightly more detail.

Recommendations:

1. Try ablating the final fallback regex:
```python
def extract_final(text):
    pattern = r"\b[A-J]\b(?!.*\b[A-J]\b)"
    match = re.search(pattern, text, re.DOTALL)
```
This is the regex responsible for most of the cases where the regex incorrectly finds an answer when the LLM judge does not. What happens if we remove this regex? It'll remove a lot of those wrong cases, but perhaps it may also remove correct cases where this final fallback regex catches the correct answer.

2. There are a lot of responses where the response continues by generating new questions and answering them. This can be confusing to parse (both from a regex and an LLM-as-a-judge standpoint). This is probably a result of the few-shot format, unclear MMLU-Pro instructions (which is the fault of the MMLU-Pro authors, not us), and of models being incapable. Consider stripping anything after "\nQuestion:" from the responses to cut most cases of these confabulated questions. (Hopefully there are very few cases where models actually legitimately output "\nQuestion:" as a rhetorical device in their CoT reasoning.)

3. We may want to do similar analysis as we run other multiple-choice evals, e.g., evals from lm-eval.

Caveat: A reasonable conclusion is that since only 2% of answers were mismatched, the regex evaluation is good enough. However it's possible that mismatched answers are particularly concentrated in some models/attacks, and the MMLU-Pro regex results of those attacked models are wholly unreliable. It is hard to determine that based on just these results since I only sampled one MMLU-Pro response from each model × attack × trial. I'm thinking once our MMLU-Pro heatmap plot comes out I can run this LLM-as-a-judge on models whose MMLU-Pro scores look especially suspicious.

Full list of mismatched outputs: https://docs.google.com/document/d/1RSlXH2Vc0gK-H2BCHzisA8IwzCrcjvk1xpbBDznOC6M/edit?usp=sharing