### PR TITLE
utils: Add function for getting git root

### DIFF
--- a/scripts/whitebox/benchmark_grid.py
+++ b/scripts/whitebox/benchmark_grid.py
@@ -9,9 +9,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import git
 import torch
 
+from safetunebed.utils import get_repo_root
 from safetunebed.whitebox.attacks.base import TamperAttack, TamperAttackConfig
 from safetunebed.whitebox.attacks.embedding_attack.embedding_attack import (
     EmbeddingAttack,
@@ -31,9 +31,7 @@ from safetunebed.whitebox.attacks.multilingual_finetune.multilingual_finetune im
 from safetunebed.whitebox.utils import AttackName, ConfigPath
 from safetunebed.whitebox.utils.benchmark.io import yaml_to_dict
 
-REPO_ROOT = Path(
-    git.Repo(".", search_parent_directories=True).working_tree_dir  # pyright: ignore[reportArgumentType]
-)
+REPO_ROOT = get_repo_root()
 
 WHITEBOX_ATTACK_CONFIG_DIR = REPO_ROOT / Path("configs", "whitebox", "attacks")
 

--- a/src/safetunebed/utils.py
+++ b/src/safetunebed/utils.py
@@ -1,0 +1,14 @@
+"""General utilities for safetunebed."""
+
+from pathlib import Path
+
+import git
+
+
+def get_repo_root() -> Path:
+    """Get the root directory of the git repository."""
+    repo = git.Repo(".", search_parent_directories=True)
+    working_dir = repo.working_tree_dir
+    if working_dir is None:
+        raise RuntimeError("Could not find git repository root")
+    return Path(working_dir)


### PR DESCRIPTION
## Changes

Adds a function for fetching the git root, which is then used in the existing file `scripts/whitebox/benchmark_grid.py` and in a script in descendant branch #44 

Child branch: #45

## Testing

In the Python interpreter:
```python
>>> from safetunebed.utils import get_repo_root; get_repo_root();
PosixPath('/Users/t/code/far/SafeTuneBed')
```
