### PR TITLE
test_mt_bench: Make it work again

### DIFF
--- a/src/safetunebed/whitebox/evals/__init__.py
+++ b/src/safetunebed/whitebox/evals/__init__.py
@@ -20,6 +20,10 @@ from safetunebed.whitebox.evals.mmlu_pro.mmlu_pro import (
     MMLUProTestEvaluation,
     MMLUProValEvaluation,
 )
+from safetunebed.whitebox.evals.mt_bench.mt_bench import (
+    MTBenchEvaluation,
+    MTBenchEvaluationConfig,
+)
 from safetunebed.whitebox.evals.strong_reject.strong_reject import (
     StrongRejectEvaluation,
     StrongRejectEvaluationConfig,
@@ -34,6 +38,8 @@ __all__ = [
     "MBPPEvaluationConfig",
     "MMLUProTestEvaluation",
     "MMLUProValEvaluation",
+    "MTBenchEvaluation",
+    "MTBenchEvaluationConfig",
     "MinervaMathEvaluation",
     "MinervaMathEvaluationConfig",
     "StrongRejectEvaluation",

--- a/src/safetunebed/whitebox/evals/mt_bench/mt_bench.py
+++ b/src/safetunebed/whitebox/evals/mt_bench/mt_bench.py
@@ -17,7 +17,11 @@ from transformers.generation.utils import GenerateOutput
 from transformers.tokenization_utils_base import BatchEncoding
 from typing_extensions import override
 
-from safetunebed.whitebox.evals.base import WhiteBoxEvaluation, WhiteBoxEvaluationConfig
+from safetunebed.whitebox.evals.base import (
+    WhiteBoxEvaluation,
+    WhiteBoxEvaluationConfig,
+    load_model_and_tokenizer,
+)
 from safetunebed.whitebox.evals.mt_bench.judge import (
     score_multi_turn,
     score_single_turn,
@@ -165,7 +169,7 @@ class MTBenchEvaluation(WhiteBoxEvaluation):
             DataFrame[InferenceSchema]: A polars DataFrame with prompts and responses.
         """
         # Standard inference path
-        model, tokenizer = self.load_model_and_tokenizer()
+        model, tokenizer = load_model_and_tokenizer(self.eval_config)
 
         inferences: list[dict] = []
         for question in tqdm(self.questions, desc="Generating MT-Bench responses"):
@@ -177,7 +181,9 @@ class MTBenchEvaluation(WhiteBoxEvaluation):
 
             # Generate turn 1 response
             prompt_t1 = self._format_prompt(messages_t1, tokenizer)
-            response_t1 = self._generate_response(prompt_t1, model, tokenizer, self.eval_config.max_generation_length)
+            response_t1 = self._generate_response(
+                prompt_t1, model, tokenizer, self.eval_config.model_config.max_generation_length
+            )
 
             # Build messages for turn 2
             messages_t2 = [
@@ -188,7 +194,9 @@ class MTBenchEvaluation(WhiteBoxEvaluation):
 
             # Generate turn 2 response
             prompt_t2 = self._format_prompt(messages_t2, tokenizer)
-            response_t2 = self._generate_response(prompt_t2, model, tokenizer, self.eval_config.max_generation_length)
+            response_t2 = self._generate_response(
+                prompt_t2, model, tokenizer, self.eval_config.model_config.max_generation_length
+            )
 
             inferences.append(
                 {

--- a/src/safetunebed/whitebox/utils/__init__.py
+++ b/src/safetunebed/whitebox/utils/__init__.py
@@ -1,5 +1,6 @@
 """Defined templates for attacks, defenses and evals in safetunebed to define form factors."""
 
+from safetunebed.whitebox.utils.datasets import get_dataset
 from safetunebed.whitebox.utils.names import (
     AttackName,
     ConfigPath,
@@ -18,4 +19,5 @@ __all__ = [
     "MetricName",
     "OptimizationDirection",
     "dealloc_model_and_tokenizer",
+    "get_dataset",
 ]

--- a/src/safetunebed/whitebox/utils/names.py
+++ b/src/safetunebed/whitebox/utils/names.py
@@ -33,6 +33,7 @@ class EvalName(StrEnum):
 
     STRONG_REJECT = "strong_reject"
     EMBEDDING_ATTACK = "embedding_attack_eval"
+    MT_BENCH = "mt_bench"
     MMLU_PRO_VAL = "mmlu_pro_val"
     MMLU_PRO_TEST = "mmlu_pro"
     MBPP = "mbpp"
@@ -46,6 +47,9 @@ class MetricName(StrEnum):
 
     STRONG_REJECT_SCORE = "strong_reject_score"
     JAILBREAK_BENCH_STRONG_REJECT_SCORE = "jailbreak_bench_strong_reject_score"
+    MT_BENCH_SCORE = "mt_bench_score"
+    MT_BENCH_TURN_1_SCORE = "mt_bench_turn_1_score"
+    MT_BENCH_TURN_2_SCORE = "mt_bench_turn_2_score"
     MMLU_PRO_ACCURACY = "mmlu_pro_accuracy"
     MBPP_PASS_AT_1 = "mbpp_pass_at_1"
     MINERVA_MATH_EXACT_MATCH = "minerva_math_exact_match"

--- a/tests/evals/test_mt_bench.py
+++ b/tests/evals/test_mt_bench.py
@@ -1,7 +1,13 @@
-"""Quick sanity check for MT-Bench evaluation using small models."""
+"""Quick sanity check for MT-Bench evaluation using small models.
+
+This is NOT a pytest test.
+
+TODO: add a pytest version that mocks the judge
+"""
 
 import argparse
 import tempfile
+from typing import TypedDict
 
 import torch
 from dotenv import load_dotenv
@@ -9,12 +15,28 @@ from dotenv import load_dotenv
 from safetunebed.whitebox.evals import MTBenchEvaluationConfig
 from safetunebed.whitebox.evals.mt_bench import MTBenchEvaluation
 from safetunebed.whitebox.evals.output_schema import EvaluationSchema
-from safetunebed.whitebox.utils.names import MetricName
+from safetunebed.whitebox.utils.models.config import ModelConfig
+from safetunebed.whitebox.utils.names import MetricName, TemplateName
 
-MODELS = {
-    "minimal": "HuggingFaceTB/SmolLM-135M",  # ~135M, base model, fastest
-    "small": "Qwen/Qwen2.5-0.5B-Instruct",  # ~0.5B, instruction-tuned
-    "medium": "Qwen/Qwen2.5-1.5B-Instruct",  # ~1.5B, instruction-tuned
+
+class _ModelSpec(TypedDict):
+    checkpoint: str
+    template: TemplateName
+
+
+MODELS: dict[str, _ModelSpec] = {
+    "minimal": {
+        "checkpoint": "HuggingFaceTB/SmolLM-135M",  # ~135M, base model, fastest
+        "template": TemplateName.GENERIC_CHAT,
+    },
+    "small": {
+        "checkpoint": "Qwen/Qwen2.5-0.5B-Instruct",  # ~0.5B, instruction-tuned
+        "template": TemplateName.QWEN,
+    },
+    "medium": {
+        "checkpoint": "Qwen/Qwen2.5-1.5B-Instruct",  # ~1.5B, instruction-tuned
+        "template": TemplateName.QWEN,
+    },
 }
 
 # Subset of categories for quick testing
@@ -23,6 +45,7 @@ QUICK_CATEGORIES = ["writing", "roleplay"]
 
 def run_eval(
     model_checkpoint: str,
+    template: TemplateName,
     categories: list[str] | None = None,
     judge_model: str = "gpt-4o",
 ) -> None:
@@ -35,11 +58,17 @@ def run_eval(
     print(f"Judge model: {judge_model}")
 
     with tempfile.TemporaryDirectory() as tmpdirname:
+        model_config = ModelConfig.from_dict(
+            {
+                "template": template,
+                "max_generation_length": 512,
+                "inference_batch_size": 1,  # MT-Bench does sequential generation for multi-turn
+            }
+        )
         eval_config = MTBenchEvaluationConfig(
             model_checkpoint=model_checkpoint,
             out_dir=tmpdirname,
-            max_generation_length=512,
-            batch_size=1,  # MT-Bench does sequential generation for multi-turn
+            model_config=model_config,
             judge_model=judge_model,
             categories=categories,
         )
@@ -80,7 +109,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     run_eval(
-        model_checkpoint=MODELS[args.tier],
+        model_checkpoint=MODELS[args.tier]["checkpoint"],
+        template=MODELS[args.tier]["template"],
         categories=None if args.full else QUICK_CATEGORIES,
         judge_model=args.judge_model,
     )


### PR DESCRIPTION
## Changes

MT-Bench was added in #40. This PR recovers some relevant code got lost, likely due to a merge where some changes were overlooked

## Testing

Ran `uv run python tests/evals/test_mt_bench.py`. Result was 
```
  Using model: Qwen/Qwen2.5-1.5B-Instruct
  Categories: ['writing', 'roleplay']
  Judge model: gpt-4o

  MT-Bench Results:
    Overall Score: 6.95
    Turn 1 Score:  7.30
    Turn 2 Score:  6.60
```
similar to scores seen in #40
