### PR TITLE
docs: Clarify that FAR cluster is only accessible to authorized people

### DIFF
--- a/docs/FAR_CLUSTER.md
+++ b/docs/FAR_CLUSTER.md
@@ -1,5 +1,7 @@
 # Development on FAR's Cluster
 
+This documentation is only relevant if you are a core contributor who has been granted access to FAR's internal cluster.
+
 For interactive development on FAR's internal cluster:
 
 **Initial setup:**


### PR DESCRIPTION
## Changes

Adds clarification that FAR cluster docs are only relevant to people with access, otherwise it can be skipped.
