### PR TITLE
Makefile: Move image path from personal account to criticalml-uw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG PYTORCH_CUDA_VERSION=2.0.1-cuda11.7-cudnn8
 FROM pytorch/pytorch:${PYTORCH_CUDA_VERSION}-runtime
+LABEL org.opencontainers.image.source=https://github.com/criticalml-uw/TamperBench
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-VERSION ?= 0.0.1
-FULL_IMAGE_NAME = ghcr.io/tomtseng/tamperbench:$(VERSION)
+VERSION ?= 0.0.0
+FULL_IMAGE_NAME = ghcr.io/criticalml-uw/tamperbench:$(VERSION)
 
 .PHONY: docker-build devbox cpu large
 


### PR DESCRIPTION
## Changes

I was pushing Docker images to my personal account, but let's push them instead to the criticalml-uw organization

## Testing

image successfully built and pushed
