### PR TITLE
k8s: Allow pulling private images

### DIFF
--- a/k8s/devbox.yaml
+++ b/k8s/devbox.yaml
@@ -75,8 +75,6 @@ spec:
                   name: openai-api-key
                   key: key
                   optional: true
-      # We're currently hosting images publicly. If we switch to hosting images
-      # privately then we will need to add this secret.
-      # imagePullSecrets:
-      #   - name: docker
+      imagePullSecrets:
+        - name: docker
       restartPolicy: Never


### PR DESCRIPTION
## Changes

PR #68 moved the Docker image to `ghcr.io/criticalml-uw/tamperbench`. However it turns out that criticalml-uw's settings don't allow public packages, or at least don't allow to make the package public. As a result I added a secret for pulling images to the `u-tamperbench` namespace on the FAR cluster, and I've modified the devbox YAML to include the secret so that the private Docker image can be pulled

## Testing

Created a devbox on the FAR cluster
