### PR TITLE
Dockerfile: Add gcc to Dockerfile, as it's necessary for vLLM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update -q \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
     # essential for running
-    git git-lfs tini \
+    # gcc is needed for vLLM's backend
+    gcc git git-lfs tini \
     # nice to have for devbox development
     curl vim tmux less sudo rsync wget \
     # CircleCI

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.0.0
+VERSION ?= 0.0.1
 FULL_IMAGE_NAME = ghcr.io/criticalml-uw/tamperbench:$(VERSION)
 
 .PHONY: docker-build devbox cpu large


### PR DESCRIPTION
## Changes

vLLM's backend (depending on the backend) may need gcc, so here we add it into the Dockerfile
