### PR TITLE
strong_reject: Load JBB dataset properly

### DIFF
--- a/src/tamperbench/whitebox/evals/strong_reject/strong_reject_jailbreak_tune.py
+++ b/src/tamperbench/whitebox/evals/strong_reject/strong_reject_jailbreak_tune.py
@@ -1,4 +1,4 @@
-"""StrongREJECT evaluator interface."""
+"""StrongREJECT and JailbreakBench jailbreak-tune evaluator variants."""
 
 # pyright: reportUnnecessaryTypeIgnoreComment=false, reportArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportMissingTypeStubs=false, reportCallIssue=false
 
@@ -11,11 +11,9 @@ from tamperbench.whitebox.attacks.jailbreak_finetune.jailbreaks import (
     JailbreakTuneType,
 )
 from tamperbench.whitebox.evals.strong_reject.strong_reject import (
+    JailbreakBenchEvaluation,
     StrongRejectEvaluation,
     StrongRejectEvaluationConfig,
-)
-from tamperbench.whitebox.utils import (
-    EvalName,
 )
 
 
@@ -51,17 +49,15 @@ class SRJailbreakTuneEvaluation(StrongRejectEvaluation[SRJailbreakTuneEvaluation
         ]
 
 
-class JBJailbreakTuneEvaluation(StrongRejectEvaluation[SRJailbreakTuneEvaluationConfig]):
-    """StrongREJECT Evaluation class using the StrongREJECT dataset."""
-
-    name: EvalName = EvalName.JAILBREAK_BENCH
+class JBJailbreakTuneEvaluation(JailbreakBenchEvaluation[SRJailbreakTuneEvaluationConfig]):
+    """JailbreakBench Evaluation class with prompt injections."""
 
     @override
     def load_strong_reject_prompts(self) -> list[str]:
-        """Load the StrongReject dataset into an Arrow Dataset, and then return prompts.
+        """Load the JailbreakBench dataset, apply jailbreak injections, and return prompts.
 
         Returns:
-            list[str]: A list of prompts from the StrongReject dataset to input to the model to obtain inferences.
+            list[str]: A list of jailbreak-wrapped prompts from the JailbreakBench dataset.
         """
         strong_reject_prompts = super().load_strong_reject_prompts()
 


### PR DESCRIPTION
## Changes

It looks like the JBB evaluation in the jailbreak-tuning code just loads the StrongREJECT dataset. This PR fixes this

## Testing

none
