### PR TITLE
circleci: Make multi-GPU tests faster

### DIFF
--- a/src/tamperbench/whitebox/utils/metrics.py
+++ b/src/tamperbench/whitebox/utils/metrics.py
@@ -296,31 +296,32 @@ def compute_helpfulness(
     if not queries:
         return []
 
-    # Generate raw outputs for each dimension separately
-    dimension_outputs: dict[str, list[str]] = {}
-
     sampling_params = SamplingParams(
         temperature=0.0,
         max_tokens=5,
         stop=None,
     )
 
-    for dimension in HELPFULNESS_DIMENSIONS:
+    # Batch all dimensions into a single vLLM call for efficiency.
+    # Build flat list of prompts: [dim0_resp0, dim0_resp1, ..., dim1_resp0, ...]
+    dimensions = list(HELPFULNESS_DIMENSIONS.keys())
+    all_prompts: list[str] = []
+    for dimension in dimensions:
         template = HELPFULNESS_DIMENSIONS[dimension]
+        all_prompts.extend(template.format(query=q, response=r) for q, r in zip(queries, responses, strict=True))
 
-        # Create prompts for this dimension
-        prompts = [template.format(query=q, response=r) for q, r in zip(queries, responses, strict=True)]
+    outputs = vllm_model.generate(all_prompts, sampling_params)
 
-        # Generate using vLLM
-        outputs = vllm_model.generate(prompts, sampling_params)
-
-        # Extract generated text
-        dimension_outputs[dimension] = [output.outputs[0].text for output in outputs]
+    # Unpack flat outputs back into per-dimension lists
+    n = len(queries)
+    dimension_outputs: dict[str, list[str]] = {}
+    for dim_idx, dimension in enumerate(dimensions):
+        dimension_outputs[dimension] = [outputs[dim_idx * n + i].outputs[0].text for i in range(n)]
 
     # Restructure to per-response dicts
     results = []
-    for i in range(len(queries)):
-        results.append({d: dimension_outputs[d][i] for d in HELPFULNESS_DIMENSIONS})
+    for i in range(n):
+        results.append({d: dimension_outputs[d][i] for d in dimensions})
 
     return parse_helpfulness_raw(results, debug=True)
 

--- a/tests/defenses/test_ctrl.py
+++ b/tests/defenses/test_ctrl.py
@@ -20,9 +20,11 @@ def test_ctrl_defense_runs(tmp_path: Path) -> None:
         output_checkpoint_path=tmp_path / "hardened_model",
         clean_dataset_name="tatsu-lab/alpaca",
         curation_rate=0.25,
-        num_samples=10,  # Small for sanity check
+        num_samples=5,  # Small for sanity check
         beam_search_rounds=2,
         beam_width=2,
+        temperatures=(0.4, 0.8),
+        top_ps=(0.4, 0.8),
         num_train_epochs=1,
         per_device_train_batch_size=4,
         learning_rate=5e-5,

--- a/tests/evals/test_strong_reject.py
+++ b/tests/evals/test_strong_reject.py
@@ -16,8 +16,13 @@ from tamperbench.whitebox.utils.names import MetricName
 
 
 @pytest.mark.gpu_required
-def test_strong_reject_evaluation() -> None:
+def test_strong_reject_evaluation(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that StrongREJECT evaluator runs and saves results correctly."""
+    # The strong_reject library handles this "TESTING" env variable to use
+    # pythia-14m as the judge model so the test doesn't download a separate
+    # large judge checkpoint.
+    monkeypatch.setenv("TESTING", "1")
+
     with tempfile.TemporaryDirectory() as tmpdirname:
         eval_config = StrongRejectEvaluationConfig(
             model_checkpoint="EleutherAI/pythia-14m",
@@ -26,10 +31,10 @@ def test_strong_reject_evaluation() -> None:
                 user_prefix="User: ",
                 assistant_prefix="Assistant: ",
                 end_turn="\n\n",
-                max_generation_length=64,
+                max_generation_length=5,
                 inference_batch_size=4,
             ),
-            max_samples=4,  # small sample for fast test
+            max_samples=2,  # small sample for fast test
         )
         evaluation = StrongRejectEvaluation(eval_config)
 


### PR DESCRIPTION
## Changes

- Make StrongREJECT test slightly faster by not loading full-sized judge model (91s -> 63s)
- Make CTRL test faster by reducing the grid search size and by batching VLLM generation calls together (191s -> 98s)

this came from asking Claude Code what some optimizations might be, not from doing actual profiling

## Testing

multi-GPU tests still pass

[times before](https://app.circleci.com/pipelines/github/criticalml-uw/TamperBench/259/workflows/52532f27-ad23-42df-b07c-6586771b236b/jobs/507):

```
============================ slowest 500 durations =============================
191.07s call     tests/defenses/test_ctrl.py::test_ctrl_defense_runs
91.06s call     tests/evals/test_strong_reject.py::test_strong_reject_evaluation
36.21s call     tests/attacks/test_lora_attack.py::test_lora_finetune_cheap
21.78s call     tests/defenses/test_booster.py::test_booster_config
18.21s call     tests/defenses/test_crl.py::test_crl_sanity_check
```

[times after](https://app.circleci.com/pipelines/github/criticalml-uw/TamperBench/262/workflows/a61c4551-34af-4b19-8ba5-f16000cc461a/jobs/515)
```
============================ slowest 500 durations =============================
97.90s call     tests/defenses/test_ctrl.py::test_ctrl_defense_runs
63.08s call     tests/evals/test_strong_reject.py::test_strong_reject_evaluation
30.40s call     tests/attacks/test_lora_attack.py::test_lora_finetune_cheap
17.31s call     tests/defenses/test_booster.py::test_booster_config
16.19s call     tests/defenses/test_crl.py::test_crl_sanity_check
```
