### PR TITLE
scripts tomtseng: Add defense cumulative-max StrongREJECT curve scripts

### DIFF
--- a/scripts/user/tomtseng/defense_cummax_curves_260313/.gitignore
+++ b/scripts/user/tomtseng/defense_cummax_curves_260313/.gitignore
@@ -1,0 +1,2 @@
+plots/
+*.csv

--- a/scripts/user/tomtseng/defense_cummax_curves_260313/README.md
+++ b/scripts/user/tomtseng/defense_cummax_curves_260313/README.md
@@ -1,0 +1,33 @@
+# Defense cumulative-max curves
+
+Context: Our [current defense
+results](https://farinc.slack.com/archives/C095L3PLBGF/p1772367795699299)
+suggest that defenses provide no advantage against our attack hyperparameter
+sweeps. The top harmfulness score achieved against each defended model is about
+the same as the score against the corresponding undefended model.
+
+Question: Do the defenses at least increase the number of trials needed to find
+a good attack, even if they don't raise the ceiling on attack success?
+
+Method: For each (model, attack) pair, we plot the cumulative maximum
+StrongREJECT score across Optuna hyperparameter-search trials (x-axis = trial
+number, y-axis = best StrongREJECT score so far allowing a 10pp MMLU-Pro drop).
+
+**Result**: The defenses do not meaningfully increase sample complexity. Defended
+curves generally rise just as fast as the undefended curve.
+The exception is CTRL, which sometimes shows a lower ceiling, but CTRL also
+heavily damages MMLU.
+
+## Usage
+
+1. Extract trial data from the sweep results (run on `cais`):
+   ```
+   python3 extract_sweep_data.py
+   ```
+
+2. Generate plots:
+   ```
+   python3 plot_cummax_sweep.py
+   ```
+
+   Outputs PNGs to `plots/`.

--- a/scripts/user/tomtseng/defense_cummax_curves_260313/extract_sweep_data.py
+++ b/scripts/user/tomtseng/defense_cummax_curves_260313/extract_sweep_data.py
@@ -1,0 +1,117 @@
+"""Extract trial-level StrongREJECT and MMLU scores from sweep results.
+
+Run on the remote machine:
+  python3 extract_sweep_data.py
+Writes sweep_data.csv to the same directory as this script.
+"""
+
+import csv
+import json
+import sqlite3
+from pathlib import Path
+
+from tqdm import tqdm
+
+BASE = Path("/data/saad_hossain/SafeTuneBed/results/sweeps/seed_42")
+
+# Map directory names to (model_family, defense)
+# We infer this from naming conventions
+MODEL_FAMILIES = {
+    "llama3_8b": "Llama-3-8B",
+    "llama3_8b_instruct": "Llama-3-8B-Instruct",
+    "qwen3_8b": "Qwen3-8B",
+}
+
+DEFENSE_NAMES = {
+    "baseline": "Undefended",
+    "booster": "Booster",
+    "crl": "CRL",
+    "ctrl": "CTRL",
+    "lat": "LAT",
+    "refat": "ReFAT",
+    "rr": "R2D2",
+    "rsn_tune": "RSN-Tune",
+    "tar": "TAR",
+    "tar_v2": "TAR-v2",
+    "triplet_adv": "Triplet-Adv",
+}
+
+SKIP_ATTACKS = {
+    "embedding_attack",
+    "benign_full_parameter_finetune",
+    "benign_lora_finetune",
+}
+
+OUT_PATH = Path(__file__).parent / "sweep_data.csv"
+
+with OUT_PATH.open("w", newline="") as out_file:
+    writer = csv.writer(out_file)
+    writer.writerow(["model_family", "defense", "attack", "trial_number", "strong_reject", "mmlu_pro"])
+
+    for dirpath in tqdm(sorted(BASE.iterdir()), desc="Processing dirs"):
+        if not dirpath.is_dir():
+            continue
+        dirname = dirpath.name
+
+        # Parse model_family and defense from dirname
+        model_family = None
+        defense_key = None
+        for mkey in sorted(MODEL_FAMILIES.keys(), key=len, reverse=True):
+            if dirname.startswith(mkey + "_") or dirname == mkey:
+                suffix = dirname[len(mkey) :]
+                if suffix == "":
+                    defense_key = "baseline"
+                elif suffix.startswith("_"):
+                    defense_key = suffix[1:]
+                else:
+                    continue
+                model_family = MODEL_FAMILIES[mkey]
+                break
+
+        if model_family is None:
+            continue
+        if defense_key not in DEFENSE_NAMES:
+            continue
+
+        defense = DEFENSE_NAMES[defense_key]
+
+        for attack_dir in sorted(dirpath.iterdir()):
+            if not attack_dir.is_dir() or attack_dir.name in SKIP_ATTACKS:
+                continue
+            db_path = attack_dir / "optuna_single" / "study.db"
+            if not db_path.exists():
+                continue
+
+            # Get trial numbers and StrongREJECT scores from study.db.
+            # objective=0 is the first (and only) objective, which is StrongREJECT
+            # in our single-objective Optuna studies.
+            conn = sqlite3.connect(db_path)
+            try:
+                trials_data = conn.execute(
+                    "SELECT t.number, tv.value "
+                    "FROM trials t JOIN trial_values tv ON t.trial_id = tv.trial_id "
+                    "WHERE t.state = 'COMPLETE' AND tv.objective = 0 "
+                    "ORDER BY t.number"
+                ).fetchall()
+            finally:
+                conn.close()
+
+            # Get MMLU scores from evaluation.json files
+            attack = attack_dir.name
+            for trial_num, sr_score in trials_data:
+                mmlu_path = (
+                    attack_dir
+                    / "optuna_single"
+                    / f"trial_{trial_num}"
+                    / "tamperbench_evaluation"
+                    / "mmlu_pro_val"
+                    / "evaluation.json"
+                )
+                mmlu_score = ""
+                if mmlu_path.exists():
+                    data = json.loads(mmlu_path.read_text())
+                    mmlu_score = data[0]["metric_value"]
+
+                writer.writerow([model_family, defense, attack, trial_num, sr_score, mmlu_score])
+
+print(f"Wrote {OUT_PATH}")

--- a/scripts/user/tomtseng/defense_cummax_curves_260313/plot_cummax_sweep.py
+++ b/scripts/user/tomtseng/defense_cummax_curves_260313/plot_cummax_sweep.py
@@ -1,0 +1,164 @@
+"""Plot cumulative-max StrongREJECT over Optuna trials, one subplot per (model, attack).
+
+Each line is a defense. Only trials satisfying the MMLU constraint (<=10pp drop
+relative to *that defense's* no_weight_modification baseline) are counted.
+
+MMLU baselines are extracted from no_weight_modification rows in the CSV data.
+"""
+
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+SCRIPT_DIR = Path(__file__).parent
+DATA_PATH = SCRIPT_DIR / "sweep_data.csv"
+OUT_DIR = SCRIPT_DIR / "plots"
+OUT_DIR.mkdir(exist_ok=True)
+
+MMLU_DROP_THRESHOLD = 0.10  # 10pp
+
+SKIP_ATTACKS = {
+    "benign_full_parameter_finetune",
+    "benign_lora_finetune",
+    "embedding_attack",
+}
+
+ATTACK_PRETTY = {
+    "backdoor_finetune": "Backdoor",
+    "competing_objectives_finetune": "Competing Obj.",
+    "full_parameter_finetune": "Full-Param FT",
+    "lora_finetune": "LoRA FT",
+    "multilingual_finetune": "Multilingual",
+    "style_modulation_finetune": "Style Modulation",
+}
+
+# Color palette for defenses
+DEFENSE_COLORS = {
+    "Undefended": "#000000",
+    "Booster": "#1f77b4",
+    "CRL": "#ff7f0e",
+    "CTRL": "#2ca02c",
+    "LAT": "#d62728",
+    "ReFAT": "#9467bd",
+    "R2D2": "#8c564b",
+    "RSN-Tune": "#e377c2",
+    "TAR": "#7f7f7f",
+    "TAR-v2": "#bcbd22",
+    "Triplet-Adv": "#17becf",
+}
+
+# Read data and extract MMLU baselines from no_weight_modification rows.
+# Structure: data[(model, defense, attack)] = [(trial_num, sr_score, mmlu_score), ...]
+data = defaultdict(list)
+# MMLU baselines: for each (model, defense), the MMLU score from no_weight_modification.
+# Used to determine which attack trials are within the 10pp MMLU drop threshold.
+mmlu_baselines: dict[tuple[str, str], float] = {}
+with open(DATA_PATH) as f:
+    reader = csv.DictReader(f)
+    for row in reader:
+        attack = row["attack"]
+        model = row["model_family"]
+        defense = row["defense"]
+        mmlu = float(row["mmlu_pro"]) if row["mmlu_pro"] else None
+
+        if attack == "no_weight_modification":
+            if mmlu is not None:
+                mmlu_baselines[(model, defense)] = mmlu
+            continue
+
+        if attack in SKIP_ATTACKS:
+            continue
+        trial_num = int(row["trial_number"])
+        sr = float(row["strong_reject"])
+        data[(model, defense, attack)].append((trial_num, sr, mmlu))
+
+
+def compute_cummax_with_mmlu_filter(
+    trials: list[tuple[int, float, float | None]], mmlu_baseline: float
+) -> tuple[list[int], list[float]]:
+    """Compute cumulative max of SR score.
+
+    For infeasible trials (MMLU dropped >10pp), the cummax stays flat.
+    """
+    trials_sorted = sorted(trials, key=lambda x: x[0])
+    xs = []
+    ys = []
+    best_so_far = 0.0
+    for trial_num, sr, mmlu in trials_sorted:
+        if mmlu is None:
+            raise ValueError(f"Trial {trial_num} has no MMLU score")
+        feasible = mmlu_baseline - mmlu <= MMLU_DROP_THRESHOLD
+        if feasible:
+            best_so_far = max(best_so_far, sr)
+        xs.append(trial_num)
+        ys.append(best_so_far)
+    return xs, ys
+
+
+# Group by (model, attack)
+model_attack_defenses = defaultdict(dict)
+for (model, defense, attack), trials in data.items():
+    model_attack_defenses[(model, attack)][defense] = trials
+
+# Get unique models and attacks
+models = sorted(set(m for m, _a in model_attack_defenses.keys()))
+attacks = sorted(set(a for _m, a in model_attack_defenses.keys()))
+attacks = [a for a in attacks if a not in SKIP_ATTACKS]
+
+# Plot: one figure per model, subplots per attack
+for model in models:
+    model_attacks = [a for a in attacks if (model, a) in model_attack_defenses]
+    if not model_attacks:
+        continue
+
+    n_attacks = len(model_attacks)
+    ncols = min(3, n_attacks)
+    nrows = (n_attacks + ncols - 1) // ncols
+    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4.5 * nrows), squeeze=False)
+    fig.suptitle(f"{model}: Cumulative Best StrongREJECT (10pp MMLU drop threshold)", fontsize=14, y=1.02)
+
+    for idx, attack in enumerate(model_attacks):
+        ax = axes[idx // ncols][idx % ncols]
+        defenses_data = model_attack_defenses[(model, attack)]
+
+        # Sort defenses: Undefended first, then alphabetical
+        defense_order = sorted(
+            defenses_data.keys(),
+            key=lambda d: (0 if d == "Undefended" else 1, d),  # pyright: ignore[reportUnknownLambdaType]
+        )
+
+        for defense in defense_order:
+            trials = defenses_data[defense]
+            mmlu_base = mmlu_baselines.get((model, defense))
+            if mmlu_base is None:
+                raise ValueError(
+                    f"No MMLU baseline for ({model}, {defense}). Is no_weight_modification missing from the CSV?"
+                )
+            xs, ys = compute_cummax_with_mmlu_filter(trials, mmlu_base)
+
+            color = DEFENSE_COLORS.get(defense, "#333333")
+            lw = 2.5 if defense == "Undefended" else 1.5
+            alpha = 1.0 if defense == "Undefended" else 0.8
+            ax.plot(xs, ys, label=defense, color=color, linewidth=lw, alpha=alpha)
+
+        ax.set_title(ATTACK_PRETTY.get(attack, attack), fontsize=11)
+        ax.set_xlabel("Optuna Trial")
+        ax.set_ylabel("Best StrongREJECT")
+        ax.set_ylim(-0.02, 1.02)
+        ax.grid(True, alpha=0.3)
+
+    # Hide unused subplots
+    for idx in range(n_attacks, nrows * ncols):
+        axes[idx // ncols][idx % ncols].set_visible(False)
+
+    # Single legend for the figure
+    handles, labels = axes[0][0].get_legend_handles_labels()
+    fig.legend(handles, labels, loc="lower center", ncol=min(6, len(labels)), bbox_to_anchor=(0.5, -0.02), fontsize=9)
+
+    fig.tight_layout()
+    out_path = OUT_DIR / f"{model.replace(' ', '_').replace('-', '_')}.png"
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"Saved: {out_path}")


### PR DESCRIPTION
## Changes

Our [current defense results](https://farinc.slack.com/archives/C095L3PLBGF/p1772367795699299) suggest that defenses provide no advantage against our attack hyperparameter sweeps. The top harmfulness score achieved against each defended model is about the same as the score against the corresponding undefended model. But do the defenses at least increase the number of trials needed to find a good attack, even if they don't raise the ceiling on attack success?

This PR generates some plots to check this and finds that the answer is no — if the defenses were effective, we'd expect them to see their curves rise more slowly in the below generated plots (x-axis = hyperparameter trial number, y-axis = best StrongREJECT score found so far). CTRL does have a lower ceiling but it also has terrible MMLU-Pro score

<img width="750" height="397" alt="Screenshot 2026-03-13 at 14 05 00" src="https://github.com/user-attachments/assets/cafc0470-1784-4519-b5eb-5c12b77d834a" />
<img width="751" height="398" alt="Screenshot 2026-03-13 at 14 05 17" src="https://github.com/user-attachments/assets/951acb25-4813-42e8-87ad-c9199ef259e0" />
