### PR TITLE
ctrl: Mix Alpaca + Dolly + Beavertails datasets rather than only using Alpaca

### DIFF
--- a/scripts/ctrl/ablation_uncurated.py
+++ b/scripts/ctrl/ablation_uncurated.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+"""Ablation: fine-tune on uncurated data with same CTRL hyperparams, then eval MMLU-Pro.
+
+This isolates whether the MMLU-Pro drop is caused by CTRL's curation or by
+the SFT procedure itself (full fine-tuning on short instruction data).
+
+Uses the same dataset mix as CTRL (Alpaca + Dolly + BeaverTails) but without curation.
+
+Results on Llama-3-8B-Instruct (baseline MMLU-Pro: 0.4393):
+  - Alpaca-only uncurated SFT:  0.0643
+  - Mixed 3-dataset uncurated SFT: 0.0571
+
+Usage:
+    python scripts/ctrl/ablation_uncurated.py --tier large
+    python scripts/ctrl/ablation_uncurated.py --model meta-llama/Meta-Llama-3-8B-Instruct
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import datasets
+from config import MODELS, get_output_dir  # pyright: ignore[reportImplicitRelativeImport]
+from dotenv import load_dotenv
+from trl.trainer.sft_config import SFTConfig
+from trl.trainer.sft_trainer import SFTTrainer
+
+from tamperbench.whitebox.defenses.ctrl.ctrl import (
+    CTRLConfig,
+    load_clean_datasets,
+    load_model,
+    load_tokenizer,
+    prepare_training_dataset,
+)
+from tamperbench.whitebox.evals.mmlu_pro.mmlu_pro import (
+    MMLUProEvaluationConfig,
+    MMLUProValEvaluation,
+)
+from tamperbench.whitebox.utils.models.config import ModelConfig
+from tamperbench.whitebox.utils.ops.isolation import run_in_isolation
+
+
+def _run_training(base_model: str, output_path_str: str, num_samples: int) -> None:
+    """Run fine-tuning in an isolated subprocess to avoid OOM with eval."""
+    output_path = Path(output_path_str)
+    config = CTRLConfig(
+        input_checkpoint_path=Path(base_model),
+        output_checkpoint_path=output_path,
+        # Use the default 3-dataset mix (Alpaca + Dolly + BeaverTails)
+        num_samples=num_samples,
+    )
+
+    print(f"\n[1/2] Loading clean datasets ({num_samples} samples)...")
+    _, clean_samples_list = load_clean_datasets(config)
+    clean_dataset = datasets.Dataset.from_list(clean_samples_list)
+
+    # Use prepare_training_dataset with empty curated set → uses original responses
+    empty_curated = datasets.Dataset.from_list([])
+    training_dataset = prepare_training_dataset(clean_dataset, empty_curated)
+    print(f"   Training dataset: {len(training_dataset)} samples (uncurated)")
+
+    print("\n[2/2] Fine-tuning on uncurated data...")
+    model = load_model(base_model)
+    tokenizer = load_tokenizer(base_model)
+
+    # Check if already done
+    config_file = output_path / "config.json"
+    model_file = output_path / "model.safetensors"
+    if config_file.exists() and config_file.stat().st_size > 0 and model_file.exists():
+        print(f"   Skipping training - model already exists at {output_path}")
+        return
+
+    model.resize_token_embeddings(new_num_tokens=len(tokenizer))
+    model.enable_input_require_grads()
+
+    training_args = SFTConfig(
+        output_dir=str(output_path),
+        per_device_train_batch_size=config.per_device_train_batch_size,
+        learning_rate=config.learning_rate,
+        num_train_epochs=config.num_train_epochs,
+        lr_scheduler_type=config.lr_scheduler_type,
+        gradient_checkpointing=True,
+        optim=config.optim,
+        logging_steps=10,
+        save_strategy="steps",
+        save_steps=500,
+        save_total_limit=1,
+        completion_only_loss=True,
+        max_length=512,
+        bf16=True,
+        report_to="none",
+        ddp_backend=None,
+    )
+
+    trainer = SFTTrainer(
+        model=model,
+        processing_class=tokenizer,
+        train_dataset=training_dataset,
+        args=training_args,
+    )
+
+    # Resume from checkpoint if one exists
+    checkpoint_dirs = list(output_path.glob("checkpoint-*"))
+    resume_from = None
+    if checkpoint_dirs:
+        latest = max(checkpoint_dirs, key=lambda p: int(p.name.split("-")[1]))
+        resume_from = str(latest)
+        print(f"   Resuming from checkpoint: {resume_from}")
+
+    trainer.train(resume_from_checkpoint=resume_from)
+    trainer.save_model(output_dir=str(output_path))
+    print(f"   Saved to {output_path}")
+
+
+def eval_mmlu_pro(model_checkpoint: str, out_dir: Path) -> float:
+    """Run MMLU-Pro val evaluation and return accuracy."""
+    eval_config = MMLUProEvaluationConfig(
+        model_checkpoint=model_checkpoint,
+        out_dir=str(out_dir),
+        model_config=ModelConfig(
+            user_prefix="",
+            assistant_prefix="",
+            end_turn="",
+            max_generation_length=2048,
+            inference_batch_size=8,
+        ),
+    )
+    evaluation = MMLUProValEvaluation(eval_config=eval_config)
+    results = evaluation.run_evaluation()
+    accuracy = float(results["metric_value"][0])
+    return accuracy
+
+
+def main() -> None:
+    """Run uncurated SFT ablation and MMLU-Pro evaluation."""
+    parser = argparse.ArgumentParser(description="Ablation: uncurated SFT + MMLU-Pro eval")
+    parser.add_argument("--tier", choices=MODELS.keys(), default="large")
+    parser.add_argument("--model", type=str, help="Override model path")
+    parser.add_argument("--skip-train", action="store_true", help="Skip training, only run eval")
+    parser.add_argument("--skip-eval", action="store_true", help="Skip eval, only run training")
+    args = parser.parse_args()
+
+    load_dotenv()
+
+    base_model = args.model or MODELS[args.tier]
+    output_dir = get_output_dir(base_model)
+    uncurated_path = output_dir / "ablation_uncurated"
+    uncurated_path.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 80)
+    print("Ablation: Uncurated SFT -> MMLU-Pro")
+    print(f"Model: {base_model}")
+    print("=" * 80)
+
+    # Fine-tune in isolated subprocess so GPU memory is fully freed before eval
+    if not args.skip_train:
+        model_path = str(uncurated_path / "model")
+        run_in_isolation(
+            target=_run_training,
+            args=(base_model, model_path, 2000),
+            error_context="Uncurated SFT fine-tuning",
+        )
+
+    # Eval MMLU-Pro on both baseline and fine-tuned
+    if not args.skip_eval:
+        print("\n" + "=" * 80)
+        print("Evaluating MMLU-Pro...")
+        print("=" * 80)
+
+        print("\n[1/2] Baseline MMLU-Pro...")
+        baseline_acc = eval_mmlu_pro(base_model, output_dir / "ablation_mmlu_baseline")
+        print(f"   Baseline MMLU-Pro accuracy: {baseline_acc:.4f}")
+
+        print("\n[2/2] Uncurated SFT MMLU-Pro...")
+        sft_acc = eval_mmlu_pro(
+            str(uncurated_path / "model"),
+            output_dir / "ablation_mmlu_uncurated",
+        )
+        print(f"   Uncurated SFT MMLU-Pro accuracy: {sft_acc:.4f}")
+
+        print("\n" + "=" * 80)
+        print("RESULTS")
+        print("=" * 80)
+        print(f"Baseline MMLU-Pro:       {baseline_acc:.4f}")
+        print(f"Uncurated SFT MMLU-Pro:  {sft_acc:.4f}")
+        print(f"Delta:                   {sft_acc - baseline_acc:+.4f}")
+
+        if baseline_acc > 0:
+            pct = (baseline_acc - sft_acc) / baseline_acc * 100
+            print(f"Relative drop:           {pct:.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ctrl/harden.py
+++ b/scripts/ctrl/harden.py
@@ -36,7 +36,7 @@ def main() -> None:
     config = CTRLConfig(
         input_checkpoint_path=Path(model),
         output_checkpoint_path=output_dir / "hardened_model",
-        clean_dataset_name="tatsu-lab/alpaca",
+        clean_dataset_names=("tatsu-lab/alpaca", "databricks/databricks-dolly-15k", "PKU-Alignment/BeaverTails"),
     )
     defense = CTRL(defense_config=config)
     checkpoint = defense.run_defense()

--- a/scripts/ctrl/run_all.py
+++ b/scripts/ctrl/run_all.py
@@ -82,7 +82,7 @@ def main() -> None:
     config = CTRLConfig(
         input_checkpoint_path=Path(base_model),
         output_checkpoint_path=output_dir / "hardened_model",
-        clean_dataset_name="tatsu-lab/alpaca",
+        clean_dataset_names=("tatsu-lab/alpaca", "databricks/databricks-dolly-15k", "PKU-Alignment/BeaverTails"),
     )
     defense = CTRL(defense_config=config)
     hardened = str(defense.run_defense())

--- a/src/tamperbench/whitebox/defenses/ctrl/ctrl.py
+++ b/src/tamperbench/whitebox/defenses/ctrl/ctrl.py
@@ -37,7 +37,8 @@ class CTRLConfig(AlignmentDefenseConfig):
     Attributes:
         input_checkpoint_path: Path to the base model (before hardening).
         output_checkpoint_path: Path where the hardened model will be saved.
-        clean_dataset_name: Name of the HuggingFace dataset to curate (e.g., "tatsu-lab/alpaca").
+        clean_dataset_names: HuggingFace dataset names to mix equally for the crowdsourced
+            pre-training data. The paper uses Alpaca, Dolly, and BeaverTails (safe subset).
         clean_dataset_split: Dataset split to use (default: "train").
         curation_rate: Fraction of dataset to curate (default: 0.25 for Attack II, use 0.05 for Attack I).
         num_samples: Total number of samples to use from dataset (default: 2000).
@@ -52,7 +53,11 @@ class CTRLConfig(AlignmentDefenseConfig):
         optim: Optimizer to use (default: "adamw_torch") - Paper Table 9 specifies AdamW.
     """
 
-    clean_dataset_name: str
+    clean_dataset_names: tuple[str, ...] = (
+        "tatsu-lab/alpaca",
+        "databricks/databricks-dolly-15k",
+        "PKU-Alignment/BeaverTails",
+    )
     clean_dataset_split: str = "train"
     curation_rate: float = 0.25
     num_samples: int = 2000
@@ -75,7 +80,7 @@ class CTRLConfig(AlignmentDefenseConfig):
     optim: str = "adamw_torch"  # Paper Table 9 specifies AdamW
 
 
-def _load_model(model_name: str) -> PreTrainedModel:
+def load_model(model_name: str) -> PreTrainedModel:
     """Load base model from checkpoint."""
     model: PreTrainedModel = AutoModelForCausalLM.from_pretrained(
         pretrained_model_name_or_path=model_name,
@@ -85,7 +90,7 @@ def _load_model(model_name: str) -> PreTrainedModel:
     return model
 
 
-def _load_tokenizer(model_name: str) -> PreTrainedTokenizer:
+def load_tokenizer(model_name: str) -> PreTrainedTokenizer:
     """Load tokenizer from checkpoint."""
     tokenizer: PreTrainedTokenizer = AutoTokenizer.from_pretrained(
         pretrained_model_name_or_path=model_name,
@@ -109,6 +114,66 @@ def _load_tokenizer(model_name: str) -> PreTrainedTokenizer:
         )
 
     return tokenizer
+
+
+def load_clean_datasets(config: CTRLConfig) -> tuple[datasets.Dataset, list[dict[str, str]]]:
+    """Load and mix clean datasets equally, as described in the CTRL paper.
+
+    The paper says crowdsourced data is "equally sampled from Alpaca, BeaverTails,
+    and Dolly". For BeaverTails, only samples with queries irrelevant to security
+    topics are used (is_safe=True).
+
+    Args:
+        config: CTRL configuration.
+
+    Returns:
+        Tuple of (raw HF dataset for curation, list of {prompt, response} dicts).
+    """
+    _SUPPORTED_DATASETS = {
+        "tatsu-lab/alpaca",
+        "databricks/databricks-dolly-15k",
+        "PKU-Alignment/BeaverTails",
+    }
+    unsupported = set(config.clean_dataset_names) - _SUPPORTED_DATASETS
+    if unsupported:
+        raise ValueError(
+            f"Unsupported dataset(s): {unsupported}. "
+            f"Supported: {_SUPPORTED_DATASETS}. "
+            f"Each dataset requires specific split/filtering logic."
+        )
+
+    samples_per_dataset = config.num_samples // len(config.clean_dataset_names)
+    all_samples: list[dict[str, str]] = []
+    all_raw_rows: list[dict[str, Any]] = []
+
+    for dataset_name in config.clean_dataset_names:
+        if dataset_name == "PKU-Alignment/BeaverTails":
+            raw = datasets.load_dataset(dataset_name, split="30k_train")
+            # Paper: "a portion of BeaverTails (with queries irrelevant to security topics)"
+            raw = raw.filter(lambda x: x["is_safe"])  # type: ignore[union-attr]  # pyright: ignore[reportUnknownLambdaType]
+        elif dataset_name == "databricks/databricks-dolly-15k":
+            raw = datasets.load_dataset(dataset_name, split="train")
+        elif dataset_name == "tatsu-lab/alpaca":
+            raw = datasets.load_dataset(dataset_name, split=config.clean_dataset_split)
+        else:
+            raise AssertionError(f"Unhandled dataset: {dataset_name}")
+
+        # Take up to samples_per_dataset
+        if len(raw) > samples_per_dataset:  # type: ignore[arg-type]
+            raw = raw.select(range(samples_per_dataset))  # type: ignore[union-attr]
+
+        for sample in raw:  # type: ignore[union-attr]
+            query, response = extract_query_response(sample)  # pyright: ignore[reportArgumentType]
+            all_samples.append({"prompt": query, "response": response})
+            all_raw_rows.append(dict(sample))
+
+    print(
+        f"   Loaded {len(all_samples)} samples from {len(config.clean_dataset_names)} datasets "
+        f"({samples_per_dataset} per dataset)"
+    )
+
+    raw_dataset = datasets.Dataset.from_list(all_raw_rows)
+    return raw_dataset, all_samples
 
 
 def prepare_training_dataset(
@@ -174,23 +239,10 @@ class CTRL(AlignmentDefense[CTRLConfig]):
         print("CTRL Defense: Robustifying via Clean Data Curation")
         print("=" * 80)
 
-        # Step 1: Load clean dataset
-        print(f"\n[1/4] Loading clean dataset ({self.defense_config.num_samples} samples)...")
-        raw_dataset: datasets.Dataset = datasets.load_dataset(  # type: ignore[assignment]
-            self.defense_config.clean_dataset_name,
-            split=self.defense_config.clean_dataset_split,
-        )
-
-        # Select subset and convert to prompt/response format
-        if len(raw_dataset) > self.defense_config.num_samples:
-            raw_dataset = raw_dataset.select(range(self.defense_config.num_samples))
-
-        clean_samples = []
-        for sample in raw_dataset:
-            query, response = extract_query_response(sample)  # pyright: ignore[reportArgumentType]
-            clean_samples.append({"prompt": query, "response": response})
+        # Step 1: Load clean datasets (equally sampled from Alpaca, Dolly, BeaverTails)
+        print(f"\n[1/4] Loading clean datasets ({self.defense_config.num_samples} samples)...")
+        raw_dataset, clean_samples = load_clean_datasets(self.defense_config)
         clean_dataset = datasets.Dataset.from_list(clean_samples)
-        print(f"   Loaded {len(clean_dataset)} clean samples")
 
         # Step 2: Curate subset of clean dataset (vLLM model loaded automatically)
         print(f"\n[2/4] Curating {self.defense_config.curation_rate * 100}% of samples...")
@@ -212,8 +264,8 @@ class CTRL(AlignmentDefense[CTRLConfig]):
 
         # Step 4: Load model and tokenizer for pre-training
         print("\n[4/4] Loading model and tokenizer for pre-training...")
-        model = _load_model(str(self.defense_config.input_checkpoint_path))
-        tokenizer = _load_tokenizer(str(self.defense_config.input_checkpoint_path))
+        model = load_model(str(self.defense_config.input_checkpoint_path))
+        tokenizer = load_tokenizer(str(self.defense_config.input_checkpoint_path))
 
         # Pre-train model on clean + curated data
         print(f"   Pre-training on {len(training_dataset)} samples ({self.defense_config.num_train_epochs} epochs)...")

--- a/src/tamperbench/whitebox/defenses/ctrl/curation.py
+++ b/src/tamperbench/whitebox/defenses/ctrl/curation.py
@@ -595,6 +595,12 @@ def extract_query_response(sample: dict[str, Any]) -> tuple[str, str]:
         if sample.get("input"):
             query = f"{query}\n\n{sample['input']}"
         response = sample["output"]
+    elif "instruction" in sample and "response" in sample:
+        # Dolly format: instruction + context + response
+        query = sample["instruction"]
+        if sample.get("context"):
+            query = f"{query}\n\n{sample['context']}"
+        response = sample["response"]
     elif "prompt" in sample and "response" in sample:
         query = sample["prompt"]
         response = sample["response"]
@@ -620,15 +626,13 @@ def extract_query_response(sample: dict[str, Any]) -> tuple[str, str]:
 
 def curate_dataset(
     config: "CTRLConfig",
-    raw_dataset: datasets.Dataset | None = None,
+    raw_dataset: datasets.Dataset,
 ) -> datasets.Dataset:
     """Curate a dataset using CTRL with automatic caching and parallelization.
 
     Args:
         config: CTRL configuration
-        raw_dataset: Pre-loaded raw dataset. If None, loads from config. Pass this
-            to avoid loading the dataset a second time when it was already loaded
-            by the caller.
+        raw_dataset: Pre-loaded raw dataset (already mixed and sized by caller).
 
     Returns:
         Curated dataset
@@ -636,7 +640,7 @@ def curate_dataset(
     # Build cache config (includes model so different models get separate caches)
     cache_config = {
         "model_name": str(config.input_checkpoint_path),
-        "dataset_name": config.clean_dataset_name,
+        "dataset_names": list(config.clean_dataset_names),
         "dataset_split": config.clean_dataset_split,
         "curation_rate": config.curation_rate,
         "num_samples": config.num_samples,
@@ -647,7 +651,7 @@ def curate_dataset(
     }
 
     # Check if curated dataset is cached
-    cache_key = f"ctrl_curated_{config.clean_dataset_name}"
+    cache_key = "ctrl_curated_" + "+".join(config.clean_dataset_names)
     cache_path = get_config_cache_path(cache_key, cache_config)
 
     if cache_path.exists():
@@ -655,17 +659,6 @@ def curate_dataset(
         return datasets.Dataset.from_list(get_dataset(cache_path, data_format="jsonl"))
 
     print("   Starting curation...")
-
-    # Load dataset if not provided
-    if raw_dataset is None:
-        raw_dataset = datasets.load_dataset(  # type: ignore[assignment]
-            config.clean_dataset_name,
-            split=config.clean_dataset_split,
-        )
-
-    # Select subset
-    if len(raw_dataset) > config.num_samples:
-        raw_dataset = raw_dataset.select(range(config.num_samples))
 
     # Determine items to curate
     num_to_curate = int(len(raw_dataset) * config.curation_rate)

--- a/tests/defenses/test_ctrl.py
+++ b/tests/defenses/test_ctrl.py
@@ -18,7 +18,7 @@ def test_ctrl_defense_runs(tmp_path: Path) -> None:
     ctrl_config = CTRLConfig(
         input_checkpoint_path=Path("HuggingFaceTB/SmolLM-135M-Instruct"),
         output_checkpoint_path=tmp_path / "hardened_model",
-        clean_dataset_name="tatsu-lab/alpaca",
+        clean_dataset_names=("tatsu-lab/alpaca",),
         curation_rate=0.25,
         num_samples=5,  # Small for sanity check
         beam_search_rounds=2,


### PR DESCRIPTION
## Changes

* `ablation_uncurated.py`: Investigation of why Llama-3-8B CTRL has such MMLU-Pro score (0.08). Turns out just fine-tuning Llama-3-8B on CTRL's original choice of datasets, without CTRL's special curation/rewriting of the dataset, also causes the same drop in MMLU-Pro score, which comes from the model always repeating the reasoning + answer from one of the few-shot examples in the MMLU-Pro query. So CTRL is maybe just broken — though we could still run our other non-MMLU-Pro evals on it, maybe it fares better in zero-shot settings
* `ctrl.py`: I noticed our implementation only uses the Alpaca dataset rather than the mix of Alpaca + Dolly + Beavertails that the original paper uses. I've changed it to use the mix since I wondered if it would fix the poor MMLU-Pro score (it doesn't)