### PR TITLE
policy_eval: Switch PolicyEval default dataset to official dataset

### DIFF
--- a/src/tamperbench/whitebox/evals/policy_eval/__init__.py
+++ b/src/tamperbench/whitebox/evals/policy_eval/__init__.py
@@ -6,7 +6,7 @@ which measures harmfulness of model outputs using an LLM as a judge.
 The benchmark uses harmful instructions across categories based on OpenAI and Meta
 usage policies:
 - Illegal Activity
-- Child Abuse Content
+- Child Abuse Content (omitted from public version of dataset)
 - Hate/Harass/Violence
 - Malware
 - Physical Harm
@@ -16,11 +16,6 @@ usage policies:
 - Political Campaigning
 - Privacy Violation Activity
 - Tailored Financial Advice
-
-Dataset:
-    The dataset is configurable via ``PolicyEvaluationConfig.dataset_name``.
-    Default: ``LLM-LAT/harmful-dataset`` (HuggingFace).
-    Alternative: ``HuggingFaceH4/LLM-Tuning-Safety`` (HEx-PHI from the original paper).
 
 Reference:
     - Paper: "Fine-tuning Aligned Language Models Compromises Safety, Even When Users Do Not Intend To!"

--- a/src/tamperbench/whitebox/evals/policy_eval/policy_eval.py
+++ b/src/tamperbench/whitebox/evals/policy_eval/policy_eval.py
@@ -17,6 +17,9 @@ The paper's benchmark uses 330 harmful prompts across 11 harm categories (30 per
     10. Privacy Violation - Collecting or exposing private information
     11. Tailored Financial Advice - Unauthorized professional financial guidance
 
+However, the public version of the dataset at LLM-Tuning-Safety/HEx-PHI has
+omitted harm category 2, so we evaluate only on the remaining 300 prompts.
+
 Scoring (LLM as Judge):
     1 = Proactive refusal aligned with policy
     2 = Restrained response with warning/generalized info
@@ -29,10 +32,13 @@ Reference:
              https://arxiv.org/abs/2310.03693
 """
 
+import csv
+import glob
 import logging
 from dataclasses import dataclass
 from typing import Any, cast
 
+import huggingface_hub
 import polars as pl
 import torch
 from datasets import load_dataset
@@ -188,7 +194,7 @@ class PolicyEvaluationConfig(WhiteBoxEvaluationConfig):
     """
 
     judge_model: str = "gpt-4o"
-    dataset_name: str = "LLM-LAT/harmful-dataset"
+    dataset_name: str = "LLM-Tuning-Safety/HEx-PHI"
     dataset_split: str = "train"
     max_judge_workers: int = 16
 
@@ -217,7 +223,16 @@ class PolicyEvaluation(WhiteBoxEvaluation[PolicyEvaluationConfig]):
 
     def _load_harmful_prompts(self) -> list[str]:
         """Load harmful prompts from the configured dataset."""
-        dataset = load_dataset(self.eval_config.dataset_name, split=self.eval_config.dataset_split)
+        dataset_name = self.eval_config.dataset_name
+
+        # HEx-PHI has a non-standard format: headerless CSVs where each row is
+        # a prompt, split across category_*.csv files. The HF datasets library
+        # misinterprets the first row as a column header, so we load the raw
+        # CSV files directly.
+        if "HEx-PHI" in dataset_name:
+            return self._load_hex_phi_prompts(dataset_name)
+
+        dataset = load_dataset(dataset_name, split=self.eval_config.dataset_split)
         prompts = []
         for raw_item in dataset:
             item = cast(dict[str, Any], raw_item)
@@ -234,6 +249,19 @@ class PolicyEvaluation(WhiteBoxEvaluation[PolicyEvaluationConfig]):
                     "Skipping dataset row with no recognized prompt field. Available keys: %s",
                     list(item.keys()),
                 )
+        return prompts
+
+    @staticmethod
+    def _load_hex_phi_prompts(dataset_name: str) -> list[str]:
+        """Load prompts from HEx-PHI headerless CSV files."""
+        path = huggingface_hub.snapshot_download(dataset_name, repo_type="dataset")
+        prompts: list[str] = []
+        for csv_file in sorted(glob.glob(f"{path}/category_*.csv")):
+            with open(csv_file) as f:
+                for row in csv.reader(f):
+                    if row and row[0].strip():
+                        prompts.append(row[0].strip())
+        logger.info("Loaded %d prompts from HEx-PHI", len(prompts))
         return prompts
 
     @override


### PR DESCRIPTION
The policy-oriented safety benchmark from [Qi et al.](https://arxiv.org/pdf/2310.03693) uses 330 prompts across 11 harm categories, released as `LLM-Tuning-Safety/HEx-PHI` (minus 1 private harm category). I think it would be better to use that as the default dataset for policy_eval rather than LLM-LAT.