### PR TITLE
cleanup: ruff: Fix file-wide ignores

### DIFF
--- a/src/tamperbench/whitebox/attacks/refusal_ablation/attack_utils.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/attack_utils.py
@@ -1,5 +1,5 @@
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedCallResult=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportPrivateImportUsage=false, reportUnusedParameter=false
-# ruff: noqa: F722
+# ruff: noqa: F722  # jaxtyping shape strings (e.g. Float[Tensor, "batch seq"]) trip F722
 """Utility functions for activation hooks and KL divergence in refusal ablation attack.
 
 Adapted from:

--- a/src/tamperbench/whitebox/attacks/refusal_ablation/model_utils.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/model_utils.py
@@ -1,5 +1,5 @@
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedCallResult=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportPrivateImportUsage=false
-# ruff: noqa: F722
+# ruff: noqa: F722  # jaxtyping shape strings (e.g. Float[Tensor, "batch seq"]) trip F722
 """Utility functions for model operations and Hugging Face Hub interactions."""
 
 import os

--- a/src/tamperbench/whitebox/attacks/refusal_ablation/refusal_ablation.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/refusal_ablation.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F722
+# ruff: noqa: F722  # jaxtyping shape strings (e.g. Float[Tensor, "batch seq"]) trip F722
 # pyright: reportMissingTypeArgument=false, reportOptionalSubscript=false, reportUnknownMemberType=false, reportUnknownVariableType=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedCallResult=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportPrivateImportUsage=false
 """Refusal Ablation Attack for SafeTuneBed.
 

--- a/src/tamperbench/whitebox/evals/ifeval/utils.py
+++ b/src/tamperbench/whitebox/evals/ifeval/utils.py
@@ -10,7 +10,6 @@ Changes from lm-evaluation-harness:
 """
 
 # pyright: reportCallIssue=false
-# ruff: noqa: D101
 
 from __future__ import annotations
 
@@ -21,6 +20,8 @@ from tamperbench.whitebox.evals.ifeval import instructions_registry
 
 @dataclasses.dataclass
 class InputExample:
+    """Input example for an IFEval instruction-following test."""
+
     key: int
     instruction_id_list: list[str]
     prompt: str
@@ -29,6 +30,8 @@ class InputExample:
 
 @dataclasses.dataclass
 class OutputExample:
+    """Result of scoring a response against an IFEval input example."""
+
     instruction_id_list: list[str]
     prompt: str
     response: str

--- a/src/tamperbench/whitebox/evals/mbpp/mbpp.py
+++ b/src/tamperbench/whitebox/evals/mbpp/mbpp.py
@@ -8,7 +8,6 @@ https://arxiv.org/abs/2108.07732
 """
 
 # pyright: reportUnknownArgumentType=false, reportUnknownMemberType=false, reportAny=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownVariableType=false, reportMissingTypeArgument=false, reportArgumentType=false, reportCallIssue=false, reportOptionalMemberAccess=false
-# ruff: noqa: D401, B905
 
 from __future__ import annotations
 
@@ -122,7 +121,7 @@ def compute_code_eval(
     fork_ctx = multiprocessing.get_context("fork")
 
     def check_correctness_fork(check_program, timeout, task_id, completion_id):
-        """Wrapper that uses fork context for multiprocessing."""
+        """Wrap check_correctness to run under the fork multiprocessing context."""
         manager = fork_ctx.Manager()
         result = manager.list()
 
@@ -148,7 +147,7 @@ def compute_code_eval(
         n_samples = 0
         results: dict = defaultdict(list)
 
-        for task_id, (candidates, test_case) in enumerate(zip(predictions, references)):
+        for task_id, (candidates, test_case) in enumerate(zip(predictions, references, strict=True)):
             for candidate in candidates:
                 test_program = candidate + "\n" + test_case
                 args = (test_program, timeout, task_id, completion_id[task_id])
@@ -184,7 +183,7 @@ def estimate_pass_at_k(num_samples: np.ndarray, num_correct: np.ndarray, k: int)
     """Estimates pass@k of each problem and returns them in an array."""
 
     def estimator(n: int, c: int, k: int) -> float:
-        """Calculates 1 - comb(n - c, k) / comb(n, k)."""
+        """Calculate 1 - comb(n - c, k) / comb(n, k)."""
         if n - c < k:
             return 1.0
         return float(1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1)))
@@ -195,7 +194,7 @@ def estimate_pass_at_k(num_samples: np.ndarray, num_correct: np.ndarray, k: int)
         assert len(num_samples) == len(num_correct)
         num_samples_it = iter(num_samples)
 
-    return np.array([estimator(int(n), int(c), k) for n, c in zip(num_samples_it, num_correct)])
+    return np.array([estimator(int(n), int(c), k) for n, c in zip(num_samples_it, num_correct, strict=True)])
 
 
 @dataclass
@@ -272,7 +271,7 @@ class MBPPEvaluation(WhiteBoxEvaluation[MBPPEvaluationConfig]):
         print(f"Postprocessing {len(responses_list)} generations...")
         processed_codes = []
         for response, prompt in tqdm(
-            zip(responses_list, prompts),
+            zip(responses_list, prompts, strict=True),
             total=len(responses_list),
             desc="Postprocessing",
         ):


### PR DESCRIPTION
## Changes

Remove some file-wide ruff `ignore`s, only keeping ignores of [F722 for jaxtyping](https://docs.kidger.site/jaxtyping/faq/#flake8-or-ruff-are-throwing-an-error) which the jaxtyping docs recommend ignoring

## Testing

lint passes
