### PR TITLE
cleanup: ruff: Remove global A002 ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ ignore = [
   "D213",  # incompatible with D212
   # TODO(tomtseng): Manually fix these lint errors in the codebase, then remove
   # these ignores
-  "A002",
   "B007",
   "B020",
   "E711",

--- a/src/tamperbench/whitebox/attacks/refusal_ablation/attack_utils.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/attack_utils.py
@@ -5,6 +5,7 @@ https://github.com/AlignmentResearch/safety_gap/attack/utils.py
 """
 
 # ruff: noqa: F722  # jaxtyping shape strings (e.g. Float[Tensor, "batch seq"]) trip F722
+# ruff: noqa: A002  # hook callbacks use `input` to match PyTorch's forward hook signature
 # Adapted external code; hook callbacks are intentionally untyped/unused.
 # pyright: reportMissingParameterType=false, reportUnusedParameter=false
 


### PR DESCRIPTION
## Changes

Remove global A002 ruff ignore (I had a TODO to get rid of it). Instead only ignore it on the one file it fires, a file which was adapted from external code anyway

## Testing

lint passes
