### PR TITLE
ruff: Remove global F721 ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,6 @@ ignore = [
   "D213",  # incompatible with D212
   # TODO(tomtseng): Manually fix these lint errors in the codebase, then remove
   # these ignores
-  "F821",
   "D413",
 ]
 

--- a/src/tamperbench/whitebox/attacks/refusal_ablation/attack_utils.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/attack_utils.py
@@ -4,7 +4,7 @@ Adapted from:
 https://github.com/AlignmentResearch/safety_gap/attack/utils.py
 """
 
-# ruff: noqa: F722  # jaxtyping shape strings (e.g. Float[Tensor, "batch seq"]) trip F722
+# ruff: noqa: F722, F821  # jaxtyping shape strings (e.g. Float[Tensor, "d_model"]) trip F722/F821
 # ruff: noqa: A002  # hook callbacks use `input` to match PyTorch's forward hook signature
 # Adapted external code; hook callbacks are intentionally untyped/unused.
 # pyright: reportMissingParameterType=false, reportUnusedParameter=false

--- a/src/tamperbench/whitebox/attacks/refusal_ablation/model_family_config.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/model_family_config.py
@@ -1,5 +1,6 @@
 """Model family configurations for different model architectures."""
 
+# ruff: noqa: F821  # jaxtyping shape strings (e.g. Float[Tensor, "d_model"]) trip F821
 # Adapted external code using transformers dynamic attributes; too noisy to annotate here.
 # pyright: reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingParameterType=false, reportImplicitAbstractClass=false, reportImplicitOverride=false
 

--- a/src/tamperbench/whitebox/attacks/refusal_ablation/model_utils.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/model_utils.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F722  # jaxtyping shape strings (e.g. Float[Tensor, "batch seq"]) trip F722
+# ruff: noqa: F722, F821  # jaxtyping shape strings (e.g. Float[Tensor, "d_model"]) trip F722/F821
 """Utility functions for model operations and Hugging Face Hub interactions."""
 
 import os

--- a/src/tamperbench/whitebox/attacks/refusal_ablation/models.py
+++ b/src/tamperbench/whitebox/attacks/refusal_ablation/models.py
@@ -1,5 +1,7 @@
 """Model wrapper classes for HuggingFace and vLLM backends."""
 
+# ruff: noqa: F821  # jaxtyping shape strings (e.g. Float[Tensor, "d_model"]) trip F821
+
 import json
 import logging
 from abc import ABC, abstractmethod


### PR DESCRIPTION
## Changes

Remove global F721 ruff ignore (I had a TODO to get rid of it). Instead only ignore it on the files it fires on, files which were adapted from external code anyway

## Testing

lint passes