### PR TITLE
ruff: Make D413-ignore an intentional style choice

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,11 +122,10 @@ ignore = [
   # include them
   "RUF001",
   # Docstring style: use D211 (no blank line before class docstring) and D212
-  # (docstring starts on same line as opening quotes)
+  # (docstring starts on same line as opening quotes). Keep docstrings compact
+  # by not requiring a trailing blank line before the closing quotes (D413)
   "D203",  # incompatible with D211
   "D213",  # incompatible with D212
-  # TODO(tomtseng): Manually fix these lint errors in the codebase, then remove
-  # these ignores
   "D413",
 ]
 


### PR DESCRIPTION
## Changes

[Ruff D413](https://docs.astral.sh/ruff/rules/missing-blank-line-after-last-section/) makes every docstring end with an extra newline. I had a TODO to resolve this but I think it's nicer to just not enforce it, it adds bloat to each docstring

## Testing

lint passes