### PR TITLE
rsn_tune: Fix merge conflict with TAR refactor

### DIFF
--- a/src/tamperbench/whitebox/defenses/rsn_tune/rsn_tune.py
+++ b/src/tamperbench/whitebox/defenses/rsn_tune/rsn_tune.py
@@ -344,7 +344,7 @@ class RSNTune(AlignmentDefense["RSNTuneConfig"]):
         return safety_neurons, foundation_neurons
 
     @override
-    def run_defense(self) -> Path:
+    def _run_defense(self) -> Path:
         # Run in a subprocess so all GPU memory (model, optimizer, compiled
         # graphs) is guaranteed freed when the process exits.
         run_in_isolation(


### PR DESCRIPTION
## Changes

Address merge conflict of RSN-tune with a refactor that came in the TAR PR #113, where I changed the method that defense subclasses need to override from `run_defense` to `_run_defense`

## Testing

Lint passes
