### PR TITLE
booster: Match original implementation on default max_grad_norm

### DIFF
--- a/src/tamperbench/whitebox/defenses/booster/booster.py
+++ b/src/tamperbench/whitebox/defenses/booster/booster.py
@@ -241,9 +241,6 @@ def _train_model(
         save_total_limit=20,  # Keep all checkpoints for evaluation
         bf16=True,
         remove_unused_columns=False,
-        # IMPORTANT: Do NOT use gradient clipping - reference implementation doesn't
-        # and it can interfere with the Booster regularizer
-        max_grad_norm=0.0,
         # Disable DDP - model uses device_map="auto" for model parallelism
         ddp_backend=None,
     )


### PR DESCRIPTION
## Changes

The original Booster codebase doesn't set `max_grad_norm`, which means it defaults to the Huggingface Trainer's default of `1.0`. Our code explicitly sets it to 0.0 and claims that it may interfere with the Booster regularizer, but I think that doesn't really make sense, the grad norm should just scale down the gradient step uniformly and not especially attenuate the regularizer. This PR makes our Booster implementation not set `max_grad_norm` so that it also defaults to 1.0.

## Testing

none
